### PR TITLE
Simplify flow execution; better parameter handling

### DIFF
--- a/commands/src/main/groovy/com/temenos/responder/flows/ComplexCustomerInformation.groovy
+++ b/commands/src/main/groovy/com/temenos/responder/flows/ComplexCustomerInformation.groovy
@@ -14,10 +14,16 @@ class ComplexCustomerInformation extends AbstractFlow {
 
     @Override
     void doExecute(ExecutionContext context) {
-        def parameters = new Parameters()
-        parameters.setValue('AddressId', context.getAttribute('AddressId') as String)
-        parameters.setValue('id', context.getAttribute('CustomerId') as String)
-        context.executeFlows([CustomerInformation, CustomerAddressFlow], parameters, ['custInfo', 'custAddress'] as String[])
+        context.buildExecution()
+                .flow(CustomerInformation)
+                .parameter('id',context.getAttribute('CustomerId') as String)
+                .into('custInfo')
+                .execution()
+            .inParallelWith(CustomerAddressFlow)
+                .parameter('AddressId', context.getAttribute('AddressId') as String)
+                .into('custAddress')
+                .execution()
+            .execute();
         def result = new Entity([
                 (ScaffoldComplexCustomer.CUSTOMER_NAME)     : context.getAttribute('custInfo').getBody().get(ScaffoldCustomer.CUSTOMER_NAME),
                 (ScaffoldComplexCustomer.CUSTOMER_ADDRESSES): context.getAttribute('custAddress').getBody().get(ScaffoldAddress.ADDRESSES)

--- a/commands/src/main/groovy/com/temenos/responder/flows/ParallelTestFlow.groovy
+++ b/commands/src/main/groovy/com/temenos/responder/flows/ParallelTestFlow.groovy
@@ -15,7 +15,14 @@ class ParallelTestFlow extends AbstractFlow {
 
     @Override
     void doExecute(ExecutionContext context) {
-        context.executeFlows([VersionInformationFlow, AdditionFlow], Parameters.none(), ['version','add'] as String[])
+        context.buildExecution()
+                .flow(VersionInformationFlow)
+                .into('version')
+                .execution()
+                .inParallelWith(AdditionFlow)
+                .into('add')
+                .execution()
+                .execute();
         context.setAttribute("finalResult", new Entity([
                 (ScaffoldParallelTestOutput.ADDITION_RESULT): context.getAttribute('add').getBody().get(ScaffoldAdditionOutput.RESULT),
                 (ScaffoldParallelTestOutput.VERSION)        : context.getAttribute('version').getBody().get(ScaffoldVersion.VERSION_NUMBER)

--- a/commands/src/test/groovy/com/temenos/responder/flows/ComplexCustomerInformationTest.groovy
+++ b/commands/src/test/groovy/com/temenos/responder/flows/ComplexCustomerInformationTest.groovy
@@ -4,6 +4,8 @@ import com.temenos.responder.commands.AddLink
 import com.temenos.responder.commands.Command
 import com.temenos.responder.context.ExecutionContext
 import com.temenos.responder.context.Parameters
+import com.temenos.responder.context.builder.ExecutionBuilder
+import com.temenos.responder.context.builder.ExecutionParameterBuilder
 import com.temenos.responder.entity.runtime.Document
 import com.temenos.responder.entity.runtime.Entity
 import com.temenos.responder.scaffold.ScaffoldAddress
@@ -21,25 +23,48 @@ class ComplexCustomerInformationTest extends Specification {
 
     @Unroll
     def "Invoke #flowNames in parallel, map data from #producerModelNames to #consumerModelName and set 'finalResult' to #data"(flowNames, List flows, data, producerModelNames, producerModels, consumerModelName, consumerModel) {
-        given:
-            def executionContext = Mock(ExecutionContext)
-            def flow = new ComplexCustomerInformation()
-            def customerInfoDoc = Mock(Document)
-            def customerAddressDoc = Mock(Document)
-            def addLink = Mock(Command)
-        when:
-            flow.execute(executionContext)
-        then:
-            executionContext.getCommand(AddLink) >> addLink
-            1 * executionContext.executeFlows(flows, { Parameters param -> param.getValue('AddressId') == '1' && param.getValue('id') == '1' }, ['custInfo', 'custAddress'] as String[])
+        given: "Parameters AddressId and CustomerId are both set to 1"
+            def executionBuilder = Mock(ExecutionBuilder)
+            def executionParameterBuilder = Mock(ExecutionParameterBuilder){
+                1 * into('custAddress') >> it
+                1 * parameter('AddressId','1') >> it
+                execution() >> executionBuilder
+            }
+            def otherExecutionBuilder = Mock(ExecutionBuilder){
+                inParallelWith(CustomerAddressFlow) >> executionParameterBuilder
+            }
+            def otherExecutionParameterBuilder = Mock(ExecutionParameterBuilder){
+                1 * flow(CustomerInformation) >> it
+                1 * into('custInfo') >> it
+                1 * parameter('id','1') >> it
+                execution() >> otherExecutionBuilder
+            }
+            def executionContext = Mock(ExecutionContext){
+                buildExecution() >> otherExecutionParameterBuilder
+                getCommand(AddLink) >> Mock(Command)
+                getAttribute('AddressId') >> '1'
+                getAttribute('CustomerId') >> '1'
+            }
+        and: "Customer information flow returns an Entity with customer ID set to '1', CustomerName set to 'John Smith' and CustomerAddress set to 'Not Known'"
+            def customerInfoDoc = Mock(Document){
+                getBody() >> new Entity(["CustomerId": 1, "CustomerName": "John Smith", "CustomerAddress": "Not Known"])
+            }
+        and: "Customer address flow returns an Entity with address ID set to '1' and Addresses set to $data"
+            def customerAddressDoc = Mock(Document){
+                getBody() >> new Entity(["AddressId": 1, "Addresses": data['Addresses']])
+            }
+        and: "The entity returned by the customer information flow will be mapped to context attribute 'custInfo'"
+            executionContext.getAttribute('custInfo') >> customerInfoDoc
+        and: "The entity returned by the customer address flow will be mapped to context attribute 'custAddress'"
+            executionContext.getAttribute('custAddress') >> customerAddressDoc
+        when: "Flow ComplexCustomerInformation is executed"
+            new ComplexCustomerInformation().execute(executionContext)
+        then:"Flows $flows*.simpleName should be executed in parallel with parameters id=1 and AddressId=1"
+            1 * executionBuilder.execute()
+        and: "The response code should be 200"
             1 * executionContext.setResponseCode(200)
-            1 * executionContext.getAttribute('AddressId') >> '1'
-            1 * executionContext.getAttribute('CustomerId') >> '1'
-            1 * executionContext.getAttribute('custInfo') >> customerInfoDoc
-            1 * executionContext.getAttribute('custAddress') >> customerAddressDoc
+        and: "Data $data should mapped to context attribute name 'finalResult'"
             1 * executionContext.setAttribute("finalResult", new Entity(data))
-            customerInfoDoc.getBody() >> new Entity(["CustomerId": 1, "CustomerName": "John Smith", "CustomerAddress": "Not Known"])
-            customerAddressDoc.getBody() >> new Entity(["AddressId": 1, "Addresses": data['Addresses']])
         where:
             flowNames                                      | flows                                      | data                                                                                                                                    | producerModelNames                      | producerModels                      | consumerModelName         | consumerModel
             ['CustomerInformation', 'CustomerAddressFlow'] | [CustomerInformation, CustomerAddressFlow] | ["CustomerName": "John Smith", "Addresses": [["HouseNumber": 1, "Road": "Station Road"], ["HouseNumber": 321, "Road": "Dustbin Road"]]] | ['ScaffoldCustomer', 'ScaffoldAddress'] | [ScaffoldCustomer, ScaffoldAddress] | 'ScaffoldComplexCustomer' | ScaffoldComplexCustomer

--- a/context/src/main/java/com/temenos/responder/context/ExecutionContext.java
+++ b/context/src/main/java/com/temenos/responder/context/ExecutionContext.java
@@ -1,6 +1,7 @@
 package com.temenos.responder.context;
 
 import com.temenos.responder.commands.Command;
+import com.temenos.responder.context.builder.ExecutionParameterBuilder;
 import com.temenos.responder.entity.runtime.Document;
 import com.temenos.responder.entity.runtime.Entity;
 import com.temenos.responder.flows.Flow;
@@ -88,7 +89,9 @@ public interface ExecutionContext extends Context {
      * @param parameters
      * @param into
      */
-    void executeFlows(List<Class<? extends Flow>> targetFlows, Parameters parameters, String... into);
+    void executeFlows(List<Class<? extends Flow>> targetFlows, List<Parameters> parameters, List<String> into);
+
+    ExecutionParameterBuilder buildExecution();
 
     Class<? extends Flow> getFlowClass();
 }

--- a/context/src/main/java/com/temenos/responder/context/builder/ExecutionBuilder.java
+++ b/context/src/main/java/com/temenos/responder/context/builder/ExecutionBuilder.java
@@ -1,0 +1,11 @@
+package com.temenos.responder.context.builder;
+
+import com.temenos.responder.flows.Flow;
+
+/**
+ * Created by dgroves on 02/02/2017.
+ */
+public interface ExecutionBuilder {
+    ExecutionParameterBuilder inParallelWith(Class<? extends Flow> flow);
+    void execute();
+}

--- a/context/src/main/java/com/temenos/responder/context/builder/ExecutionParameterBuilder.java
+++ b/context/src/main/java/com/temenos/responder/context/builder/ExecutionParameterBuilder.java
@@ -1,0 +1,15 @@
+package com.temenos.responder.context.builder;
+
+import com.temenos.responder.context.Parameters;
+import com.temenos.responder.flows.Flow;
+
+/**
+ * Created by dgroves on 02/02/2017.
+ */
+public interface ExecutionParameterBuilder {
+    ExecutionParameterBuilder flow(Class<? extends Flow> flow);
+    ExecutionParameterBuilder parameters(Parameters parameters);
+    ExecutionParameterBuilder parameter(String name, String value);
+    ExecutionParameterBuilder into(String attributeName);
+    ExecutionBuilder execution();
+}

--- a/context/src/main/java/com/temenos/responder/entity/runtime/Entity.java
+++ b/context/src/main/java/com/temenos/responder/entity/runtime/Entity.java
@@ -106,7 +106,12 @@ public class Entity {
      */
     public <T> T get(String key, Class<T> expected) throws EntityException {
         Object value = get(key);
-        Class<?> valueType = value.getClass();
+        Class<?> valueType;
+        if(value == null){
+            valueType = Void.class;
+        }else {
+            valueType = value.getClass();
+        }
         if (!expected.isAssignableFrom(valueType)) {
             throw new TypeMismatchException(String.format(INVALID_TYPE_MSG,
                     expected.getSimpleName(), valueType.getSimpleName()));
@@ -363,7 +368,11 @@ public class Entity {
         } else {
             if (!baseKey.isEmpty()) {
                 accessors.put(baseKey, properties);
-                fqAccessorNameAndType.put(baseKey, Type.fromStaticType(properties.getClass()));
+                if(properties == null){
+                    fqAccessorNameAndType.put(baseKey, Type.fromStaticType(Void.class));
+                }else {
+                    fqAccessorNameAndType.put(baseKey, Type.fromStaticType(properties.getClass()));
+                }
             }
         }
     }

--- a/context/src/test/groovy/com/temenos/responder/entity/runtime/EntityTest.groovy
+++ b/context/src/test/groovy/com/temenos/responder/entity/runtime/EntityTest.groovy
@@ -35,6 +35,7 @@ class EntityTest extends Specification {
             'Greeting.Subject[0][1].LastName' | ["Greeting": ["Subject": [[["LastName": "Ferrari"], ["LastName": "Lamborghini"], ["LastName": "Escort"]]]]] | "Lamborghini"
             'Greeting.Subject'                | ["Greeting": ["Subject": "Everybody"], "Greeting.Subject": "World"]                                         | "Everybody"
             'Greeting\\.Subject'              | ["Greeting": ["Subject": "Everybody"], "Greeting.Subject": "World"]                                         | "World"
+            'Greeting'                        | ['Greeting': null]                                                                                          | null
     }
 
     @Unroll
@@ -63,6 +64,23 @@ class EntityTest extends Specification {
             'Greeting.Subject[0][1].LastName' | ["Greeting": ["Subject": [[["LastName": "Ferrari"], ["LastName": "Lamborghini"], ["LastName": "Escort"]]]]] | "Lamborghini"                             | String.class
             'Greeting.Subject'                | ["Greeting": ["Subject": "Everybody"], "Greeting.Subject": "World"]                                         | "Everybody"                               | String.class
             'Greeting\\.Subject'              | ["Greeting": ["Subject": "Everybody"], "Greeting.Subject": "World"]                                         | "World"                                   | String.class
+    }
+
+    @Unroll
+    def "Access null value from entity #map using #key and declared type Void.class"(key, map) {
+        given:
+            def entity = new Entity(map)
+        when:
+            def result = entity.get(key, Void.class)
+        then:
+            result == null
+        where:
+            key                   | map
+            'Greeting'            | ['Greeting': null]
+            'Greeting.Subject'    | ['Greeting': ['Subject': null]]
+            'Greeting[0]'         | ['Greeting': [null, null, null]]
+            'Greeting[0].Subject' | ['Greeting': [['Subject': null]]]
+
     }
 
     @Unroll
@@ -120,25 +138,33 @@ class EntityTest extends Specification {
             entity.getValues() == newStructure
             entity.get(key) == value
         where:
-            key                             | value          | originalStructure                                                                         | newStructure
-            'Greeting'                      | 'Hello'        | [:]                                                                                       | ["Greeting": "Hello"]
-            'Greeting.Subject'              | 'World'        | [:]                                                                                       | ["Greeting": ["Subject": "World"]]
-            'Greeting[0]'                   | 'World'        | [:]                                                                                       | ["Greeting": ["World"]]
-            'Greeting'                      | 'Ciao'         | ['Greeting': 'Hello']                                                                     | ["Greeting": "Ciao"]
-            'Subject'                       | 'World'        | ['Greeting': 'Hello']                                                                     | ["Greeting": "Hello", "Subject": "World"]
-            'Greeting\\.Subject'            | 'Everybody'    | ["Greeting": ["Greeting": "Hello", "Subject": "World"]]                                   | ["Greeting": ["Greeting": "Hello", "Subject": "World"], "Greeting.Subject": "Everybody"]
-            'Greeting\\.Subject'            | 'Everybody'    | ['Greeting.Subject': 'World']                                                             | ['Greeting.Subject': 'Everybody']
-            'Greeting.Subject'              | 'Everybody'    | ["Greeting": ["Greeting": "Hello", "Subject": "World"]]                                   | ["Greeting": ["Greeting": "Hello", "Subject": "Everybody"]]
-            'Greeting.Subject.Location'     | 'World'        | ["Greeting": ["Subject": ["Location": "Everywhere"]]]                                     | ["Greeting": ["Subject": ["Location": "World"]]]
-            'Greeting[0]'                   | 'Ciao'         | ["Greeting": ["Hello", "Bonjour", "Guten Tag"]]                                           | ["Greeting": ["Ciao", "Bonjour", "Guten Tag"]]
-            'Greeting[1]'                   | 'Ciao'         | ["Greeting": ["Hello"]]                                                                   | ["Greeting": ["Hello", "Ciao"]]
-            'Greeting[0].Greeting'          | 'Ciao'         | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]] | ["Greeting": [["Greeting": "Ciao"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]
-            'Greeting[0].Subject'           | 'Everyone'     | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]] | ["Greeting": [["Greeting": "Hello", "Subject": "Everyone"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]
-            'Greeting[3].Subject'           | 'Everyone'     | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]] | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"], ["Subject": "Everyone"]]]
-            'Greeting.Subject[0].Location'  | 'World'        | ["Greeting": ["Subject": [["Location": "Everywhere"]]]]                                   | ["Greeting": ["Subject": [["Location": "World"]]]]
-            'Address[0].Address[0].Address' | 'Station Road' | [:]                                                                                       | ['Address': [['Address': [["Address": "Station Road"]]]]]
-            'Address[0].Address[1].Address' | 'Station Road' | ["Address": [['Address': [['Address': 'Turing Road']]]]]                                  | ['Address': [['Address': [["Address": "Turing Road"], ["Address": "Station Road"]]]]]
-            'Address[0].Address[0].Address' | 'Station Road' | ["Address": [['Address': [['Address': 'Turing Road']]]]]                                  | ['Address': [['Address': [["Address": "Station Road"]]]]]
+            key                             | value          | originalStructure                                                                                                                                                                                                                                                                 | newStructure
+            'Greeting'                      | 'Hello'        | [:]                                                                                                                                                                                                                                                                               | ["Greeting": "Hello"]
+            'Greeting.Subject'              | 'World'        | [:]                                                                                                                                                                                                                                                                               | ["Greeting": ["Subject": "World"]]
+            'Greeting[0]'                   | 'World'        | [:]                                                                                                                                                                                                                                                                               | ["Greeting": ["World"]]
+            'Greeting'                      | 'Ciao'         | ['Greeting': 'Hello']                                                                                                                                                                                                                                                             | ["Greeting": "Ciao"]
+            'Subject'                       | 'World'        | ['Greeting': 'Hello']                                                                                                                                                                                                                                                             | ["Greeting": "Hello", "Subject": "World"]
+            'Greeting\\.Subject'            | 'Everybody'    | ["Greeting": ["Greeting": "Hello", "Subject": "World"]]                                                                                                                                                                                                                           | ["Greeting": ["Greeting": "Hello", "Subject": "World"], "Greeting.Subject": "Everybody"]
+            'Greeting\\.Subject'            | 'Everybody'    | ['Greeting.Subject': 'World']                                                                                                                                                                                                                                                     | ['Greeting.Subject': 'Everybody']
+            'Greeting.Subject'              | 'Everybody'    | ["Greeting": ["Greeting": "Hello", "Subject": "World"]]                                                                                                                                                                                                                           | ["Greeting": ["Greeting": "Hello", "Subject": "Everybody"]]
+            'Greeting.Subject.Location'     | 'World'        | ["Greeting": ["Subject": ["Location": "Everywhere"]]]                                                                                                                                                                                                                             | ["Greeting": ["Subject": ["Location": "World"]]]
+            'Greeting[0]'                   | 'Ciao'         | ["Greeting": ["Hello", "Bonjour", "Guten Tag"]]                                                                                                                                                                                                                                   | ["Greeting": ["Ciao", "Bonjour", "Guten Tag"]]
+            'Greeting[1]'                   | 'Ciao'         | ["Greeting": ["Hello"]]                                                                                                                                                                                                                                                           | ["Greeting": ["Hello", "Ciao"]]
+            'Greeting[10]'                  | 'Hola'         | ["Greeting": ["Hello", "Hey", "Howdy", "Hi", "Good day", "Yo", "Good evening", "Guten Tag", "Bonjour", "Ciao"]]                                                                                                                                                                   | ["Greeting": ["Hello", "Hey", "Howdy", "Hi", "Good day", "Yo", "Good evening", "Guten Tag", "Bonjour", "Ciao", "Hola"]]
+            'Greeting[10]'                  | 'Hej'          | ["Greeting": ["Hello", "Hey", "Howdy", "Hi", "Good day", "Yo", "Good evening", "Guten Tag", "Bonjour", "Ciao", "Hola"]]                                                                                                                                                           | ["Greeting": ["Hello", "Hey", "Howdy", "Hi", "Good day", "Yo", "Good evening", "Guten Tag", "Bonjour", "Ciao", "Hej"]]
+            'Greeting[10].Greeting'         | 'Hej'          | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Hey"], ["Greeting": "Howdy"], ["Greeting": "Hi"], ["Greeting": "Good day"], ["Greeting": "Yo"], ["Greeting": "Good evening"], ["Greeting": "Guten Tag"], ["Greeting": "Bonjour"], ["Greeting": "Ciao"]]]                       | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Hey"], ["Greeting": "Howdy"], ["Greeting": "Hi"], ["Greeting": "Good day"], ["Greeting": "Yo"], ["Greeting": "Good evening"], ["Greeting": "Guten Tag"], ["Greeting": "Bonjour"], ["Greeting": "Ciao"], ["Greeting": "Hej"]]]
+            'Greeting[10].Greeting'         | 'Hej'          | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Hey"], ["Greeting": "Howdy"], ["Greeting": "Hi"], ["Greeting": "Good day"], ["Greeting": "Yo"], ["Greeting": "Good evening"], ["Greeting": "Guten Tag"], ["Greeting": "Bonjour"], ["Greeting": "Ciao"], ["Greeting": "Hola"]]] | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Hey"], ["Greeting": "Howdy"], ["Greeting": "Hi"], ["Greeting": "Good day"], ["Greeting": "Yo"], ["Greeting": "Good evening"], ["Greeting": "Guten Tag"], ["Greeting": "Bonjour"], ["Greeting": "Ciao"], ["Greeting": "Hej"]]]
+            'Greeting[0].Greeting'          | 'Ciao'         | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]                                                                                                                                                                                         | ["Greeting": [["Greeting": "Ciao"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]
+            'Greeting[0].Subject'           | 'Everyone'     | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]                                                                                                                                                                                         | ["Greeting": [["Greeting": "Hello", "Subject": "Everyone"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]
+            'Greeting[3].Subject'           | 'Everyone'     | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"]]]                                                                                                                                                                                         | ["Greeting": [["Greeting": "Hello"], ["Greeting": "Bonjour"], ["Greeting": "Guten Tag"], ["Subject": "Everyone"]]]
+            'Greeting.Subject[0].Location'  | 'World'        | ["Greeting": ["Subject": [["Location": "Everywhere"]]]]                                                                                                                                                                                                                           | ["Greeting": ["Subject": [["Location": "World"]]]]
+            'Address[0].Address[0].Address' | 'Station Road' | [:]                                                                                                                                                                                                                                                                               | ['Address': [['Address': [["Address": "Station Road"]]]]]
+            'Address[0].Address[1].Address' | 'Station Road' | ["Address": [['Address': [['Address': 'Turing Road']]]]]                                                                                                                                                                                                                          | ['Address': [['Address': [["Address": "Turing Road"], ["Address": "Station Road"]]]]]
+            'Address[0].Address[0].Address' | 'Station Road' | ["Address": [['Address': [['Address': 'Turing Road']]]]]                                                                                                                                                                                                                          | ['Address': [['Address': [["Address": "Station Road"]]]]]
+            'Address'                       | null           | ["Address": 'Turing Road']                                                                                                                                                                                                                                                        | ["Address": null]
+            'Greeting.Subject'              | null           | ["Greeting": ["Greeting": "Hello"]]                                                                                                                                                                                                                                               | ["Greeting": ["Greeting": "Hello", "Subject": null]]
+            'Greeting[0]'                   | null           | ["Greeting": ["Hello", "Ciao", "Hola", "Bonjour"]]                                                                                                                                                                                                                                | ["Greeting": [null, "Ciao", "Hola", "Bonjour"]]
+            'Greeting[1]'                   | null           | ["Greeting": ["Hello"]]                                                                                                                                                                                                                                                           | ["Greeting": ["Hello", null]]
     }
 
     @Unroll
@@ -152,6 +178,7 @@ class EntityTest extends Specification {
             'Greeting'                      | 'Hello'                           | ["Greeting": 'Hello']
             'Greetings'                     | ['Hello', 'Bonjour', 'Guten Tag'] | ['Greetings': ['Hello', 'Bonjour', 'Guten Tag']]
             'Greetings[0]'                  | 'Hello'                           | ['Greetings': ['Hello']]
+            'Greetings[1]'                  | 'Hello'                           | ['Greetings': ['Hello']]
             'Greetings[0][1]'               | 'Hello'                           | ['Greetings': [['Hello']]]
             'Greetings[0].Subject'          | 'Everybody'                       | ['Greetings': [['Subject': 'Everybody']]]
             'Greetings[0][1].Subject'       | 'Hello'                           | ['Greetings': [[['Subject': 'Hello']]]]
@@ -178,6 +205,7 @@ class EntityTest extends Specification {
             'Greetings\\.Greeting.Greeting'           | ['Greeting', 'Greetings.Greeting']
             'Greetings.Subject.Location'              | ['Location', 'Subject', 'Greetings']
             'Address[0].Address[0].Address'           | ['Address', '[]', 'Address', '[]', 'Address']
+            'Address[10].Address[10].Address'         | ['Address', '[]', 'Address', '[]', 'Address']
     }
 
 }

--- a/dispatcher/src/main/java/com/temenos/responder/context/CrossFlowContext.java
+++ b/dispatcher/src/main/java/com/temenos/responder/context/CrossFlowContext.java
@@ -25,6 +25,9 @@ public interface CrossFlowContext extends ParameterisedContext {
      *
      * @return A {@link List list} of parameter values.
      */
+    List<Parameters> allParameters();
+
+
     Parameters parameters();
 
     /**

--- a/dispatcher/src/main/java/com/temenos/responder/context/DefaultCrossFlowContext.java
+++ b/dispatcher/src/main/java/com/temenos/responder/context/DefaultCrossFlowContext.java
@@ -12,15 +12,15 @@ import java.util.concurrent.ConcurrentHashMap;
 public class DefaultCrossFlowContext implements CrossFlowContext {
 
     private final Origin origin;
-    private final Parameters parameters;
+    private final List<Parameters> parameters;
     private final List<String> into;
     private final Map<String, Object> attributes;
 
-    public DefaultCrossFlowContext(Origin origin, Parameters parameters, List<String> into){
+    public DefaultCrossFlowContext(Origin origin, List<Parameters> parameters, List<String> into){
         this(origin, parameters, into, new ConcurrentHashMap<>());
     }
 
-    DefaultCrossFlowContext(Origin origin, Parameters parameters, List<String> into, Map<String,Object> attributes){
+    DefaultCrossFlowContext(Origin origin, List<Parameters> parameters, List<String> into, Map<String,Object> attributes){
         this.parameters = parameters;
         this.into = into;
         this.origin = origin;
@@ -44,8 +44,13 @@ public class DefaultCrossFlowContext implements CrossFlowContext {
     }
 
     @Override
-    public Parameters parameters() {
+    public List<Parameters> allParameters() {
         return parameters;
+    }
+
+    @Override
+    public Parameters parameters() {
+        return parameters.get(0);
     }
 
     @Override

--- a/dispatcher/src/main/java/com/temenos/responder/context/DefaultExecutionContext.java
+++ b/dispatcher/src/main/java/com/temenos/responder/context/DefaultExecutionContext.java
@@ -6,6 +6,8 @@ import com.temenos.responder.commands.Command;
 import com.temenos.responder.commands.injector.CommandInjector;
 import com.temenos.responder.context.builder.ContextBuilderFactory;
 import com.temenos.responder.context.builder.CrossFlowContextBuilder;
+import com.temenos.responder.context.builder.ExecutionParameterBuilder;
+import com.temenos.responder.context.builder.FlowExecutionParameterBuilder;
 import com.temenos.responder.context.manager.ContextManager;
 import com.temenos.responder.context.manager.DefaultContextManager;
 import com.temenos.responder.dispatcher.Dispatcher;
@@ -129,15 +131,20 @@ public class DefaultExecutionContext implements ExecutionContext {
     }
 
     @Override
-    public void executeFlows(List<Class<? extends Flow>> targetFlows, Parameters from, String... into) {
+    public void executeFlows(List<Class<? extends Flow>> targetFlows, List<Parameters> from, List<String> into) {
         try (CrossFlowContextBuilder builder = factory.getCrossFlowContextBuilder(manager)) {
-            this.contextAttributes.putAll(this.dispatcher.notify(targetFlows, crossFlowContext(builder, flowClass, into, from), into));
+            this.contextAttributes.putAll(this.dispatcher.notify(targetFlows, crossFlowContext(builder, flowClass, into, from)));
         }
     }
 
     @Override
     public String getInternalResource(String resourcePath) {
         return this.serverRoot + resourcePath;
+    }
+
+    @Override
+    public ExecutionParameterBuilder buildExecution() {
+        return new FlowExecutionParameterBuilder(this);
     }
 
     private long crossFlowContext(CrossFlowContextBuilder builder, Class<? extends Flow> sourceFlow, String into, Parameters from) {
@@ -148,7 +155,7 @@ public class DefaultExecutionContext implements ExecutionContext {
                 .buildAndGetId();
     }
 
-    private long crossFlowContext(CrossFlowContextBuilder builder, Class<? extends Flow> sourceFlow, String[] into, Parameters from) {
+    private long crossFlowContext(CrossFlowContextBuilder builder, Class<? extends Flow> sourceFlow, List<String> into, List<Parameters> from) {
         return builder
                 .origin(this.serverRoot, this.self, sourceFlow)
                 .parameters(from)

--- a/dispatcher/src/main/java/com/temenos/responder/context/builder/CrossFlowContextBuilder.java
+++ b/dispatcher/src/main/java/com/temenos/responder/context/builder/CrossFlowContextBuilder.java
@@ -21,7 +21,7 @@ import java.util.*;
 public class CrossFlowContextBuilder implements ContextBuilder<CrossFlowContext>, AutoCloseable {
 
     private Origin origin;
-    private Parameters parameters;
+    private List<Parameters> parameters = new ArrayList<>();
     private List<String> into = new ArrayList<>();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CrossFlowContextBuilder.class);
@@ -33,25 +33,23 @@ public class CrossFlowContextBuilder implements ContextBuilder<CrossFlowContext>
         return this;
     }
 
-    public CrossFlowContextBuilder parameters(String key, String value){
-        parameters.setValue(key, value);
-        return this;
-    }
-
-    public CrossFlowContextBuilder parameters(Map<String, String> values){
-        for(Map.Entry<String,String> entry : values.entrySet()){
-            parameters.setValue(entry.getKey(), entry.getValue());
-        }
-        return this;
-    }
-
-    public CrossFlowContextBuilder parameters(Parameters parameters){
+    public CrossFlowContextBuilder parameters(List<Parameters> parameters){
         this.parameters = parameters;
         return this;
     }
 
-    public CrossFlowContextBuilder into(String... into){
-        this.into.addAll(Arrays.asList(into));
+    public CrossFlowContextBuilder parameters(Parameters parameters){
+        this.parameters.add(parameters);
+        return this;
+    }
+
+    public CrossFlowContextBuilder into(String into){
+        this.into.add(into);
+        return this;
+    }
+
+    public CrossFlowContextBuilder into(List<String> into){
+        this.into.addAll(into);
         return this;
     }
 

--- a/dispatcher/src/main/java/com/temenos/responder/context/builder/FlowExecutionBuilder.java
+++ b/dispatcher/src/main/java/com/temenos/responder/context/builder/FlowExecutionBuilder.java
@@ -1,0 +1,57 @@
+package com.temenos.responder.context.builder;
+
+import com.temenos.responder.context.ExecutionContext;
+import com.temenos.responder.context.Parameters;
+import com.temenos.responder.flows.Flow;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by dgroves on 02/02/2017.
+ */
+public class FlowExecutionBuilder implements ExecutionBuilder {
+
+    private FlowExecutionParameterBuilder parameterBuilder;
+    private ExecutionContext ctx;
+
+    public FlowExecutionBuilder(ExecutionContext ctx){
+        this.ctx = ctx;
+    }
+
+    public FlowExecutionBuilder(ExecutionContext ctx, FlowExecutionParameterBuilder parameterBuilder){
+        this.ctx = ctx;
+        this.parameterBuilder = parameterBuilder;
+    }
+
+    @Override
+    public ExecutionParameterBuilder inParallelWith(Class<? extends Flow> flow) {
+        return new FlowExecutionParameterBuilder(this, ctx).flow(flow);
+    }
+
+    @Override
+    public void execute() {
+        List<FlowExecutionParameterBuilder.FlowExecutionParameters> executionParameters = new ArrayList<>();
+        FlowExecutionBuilder executionBuilder = this;
+        do {
+            FlowExecutionParameterBuilder parameterBuilder = executionBuilder.parameterBuilder;
+            executionParameters.add(parameterBuilder.build());
+            executionBuilder = parameterBuilder.getExecutionBuilder();
+        }while(executionBuilder != null);
+        if(executionParameters.size() == 1){
+            FlowExecutionParameterBuilder.FlowExecutionParameters params = executionParameters.get(0);
+            ctx.executeFlow(params.getFlow(), params.getParameters(), params.getIntoAttribute());
+        }else{
+            List<Class<? extends Flow>> flows = new ArrayList<>();
+            List<Parameters> parameters = new ArrayList<>();
+            List<String> into = new ArrayList<>();
+            executionParameters.forEach(it -> {
+                flows.add(it.getFlow());
+                parameters.add(it.getParameters());
+                into.add(it.getIntoAttribute());
+            });
+            ctx.executeFlows(flows, parameters, into);
+        }
+    }
+
+}

--- a/dispatcher/src/main/java/com/temenos/responder/context/builder/FlowExecutionParameterBuilder.java
+++ b/dispatcher/src/main/java/com/temenos/responder/context/builder/FlowExecutionParameterBuilder.java
@@ -1,0 +1,90 @@
+package com.temenos.responder.context.builder;
+
+import com.temenos.responder.context.ExecutionContext;
+import com.temenos.responder.context.Parameters;
+import com.temenos.responder.flows.Flow;
+
+/**
+ * Created by dgroves on 02/02/2017.
+ */
+public class FlowExecutionParameterBuilder implements ExecutionParameterBuilder {
+
+    private ExecutionContext ctx;
+    private Class<? extends Flow> flow;
+    private Parameters parameters = new Parameters();
+    private String intoAttribute;
+    private FlowExecutionBuilder executionBuilder;
+
+    public FlowExecutionParameterBuilder(ExecutionContext ctx){
+        this.parameters = new Parameters();
+        this.ctx = ctx;
+    }
+
+    public FlowExecutionParameterBuilder(FlowExecutionBuilder executionBuilder, ExecutionContext ctx){
+        this.executionBuilder = executionBuilder;
+        this.ctx = ctx;
+    }
+
+    FlowExecutionParameters build(){
+        return new FlowExecutionParameters(flow, parameters, intoAttribute);
+    }
+
+    @Override
+    public ExecutionParameterBuilder flow(Class<? extends Flow> flow) {
+        this.flow = flow;
+        return this;
+    }
+
+    @Override
+    public ExecutionParameterBuilder parameters(Parameters parameters) {
+        this.parameters = parameters;
+        return this;
+    }
+
+    @Override
+    public ExecutionParameterBuilder parameter(String name, String value) {
+        this.parameters.setValue(name, value);
+        return this;
+    }
+
+    @Override
+    public ExecutionParameterBuilder into(String attributeName) {
+        this.intoAttribute = attributeName;
+        return this;
+    }
+
+    @Override
+    public ExecutionBuilder execution() {
+        return new FlowExecutionBuilder(ctx, this);
+    }
+
+    public FlowExecutionBuilder getExecutionBuilder(){
+        return this.executionBuilder;
+    }
+
+    public static class FlowExecutionParameters {
+
+        private Class<? extends Flow> flow;
+        private Parameters parameters;
+        private String intoAttribute;
+
+        private FlowExecutionParameters(Class<? extends Flow> flow, Parameters parameters, String intoAttribute){
+            this.flow = flow;
+            this.parameters = parameters;
+            this.intoAttribute = intoAttribute;
+        }
+
+        public Class<? extends Flow> getFlow(){
+            return flow;
+        }
+
+        public Parameters getParameters(){
+            return parameters;
+        }
+
+        public String getIntoAttribute(){
+            return intoAttribute;
+        }
+    }
+
+}

--- a/dispatcher/src/main/java/com/temenos/responder/dispatcher/Dispatcher.java
+++ b/dispatcher/src/main/java/com/temenos/responder/dispatcher/Dispatcher.java
@@ -30,10 +30,9 @@ public interface Dispatcher {
     /**
      * Notify the dispatcher instance that multiple {@link Flow flows} are available to execute in parallel.
      *
-     * @param flow
+     * @param flows
      * @param crossFlowContextId
-     * @param into
      * @return
      */
-    Map<String, Document> notify(List<Class<? extends Flow>> flow, long crossFlowContextId, String... into);
+    Map<String, Document> notify(List<Class<? extends Flow>> flows, long crossFlowContextId);
 }

--- a/dispatcher/src/test/groovy/com/temenos/responder/context/DefaultExecutionContextTest.groovy
+++ b/dispatcher/src/test/groovy/com/temenos/responder/context/DefaultExecutionContextTest.groovy
@@ -50,7 +50,7 @@ class DefaultExecutionContextTest extends Specification {
     }
 
     @Unroll
-    def "Notify dispatchers that #flows.simpleName are ready to execute in parallel with parameters and map the results to #into"(List<Class<Flow>> flows, String[] into) {
+    def "Notify dispatchers that #flows.simpleName are ready to execute in parallel with parameters and map the results to #into"(flows, into) {
         given: "A parent flow executed from a resource"
             def serverRoot = 'http://0.0.0.0/root'
             def self = 'http://0.0.0.0/root/resource'
@@ -71,14 +71,14 @@ class DefaultExecutionContextTest extends Specification {
                 factory.getCrossFlowContextBuilder(manager) >> builder
             }
             def context = Mock(CrossFlowContext)
-            def from = Mock(Parameters)
+            def from = [Mock(Parameters)]
             def executionContext = new DefaultExecutionContext(serverRoot, self, resourceName, null, contextAttributes, null, dispatcher, factory, manager, ParallelTestFlow)
         when: "A list of flows are made available to the dispatcher"
             executionContext.executeFlows(flows, from, into)
         then: "The result of each flow must be mapped to a respective context attribute name"
             contextAttributes == responseData
         and: "The dispatcher will execute the given flows and will map each result to each parameter name"
-            1 * dispatcher.notify(flows, 1, into) >> responseData
+            1 * dispatcher.notify(flows, 1) >> responseData
         where:
             flows                                                              | into
             [VersionInformationFlow, CustomerAddressFlow, CustomerInformation] | ['versionResult', 'addressResult', 'customerInfoResult']


### PR DESCRIPTION
This commit implements two builder classes to simplify the interface for
executing a flow from another flow and also changes the flow dispatcher
class to use one parameter object per flow.